### PR TITLE
chore(release)!: Move to io.funktional org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,15 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         run: mkdir -p modules/redis-rediculous/target modules/core-tests/target modules/redis-rediculous-tests/target modules/db-migration/target modules/example/target modules/flags/target modules/http-client/target modules/rabbitmq-fs2-tests/target modules/db-skunk-tests/target modules/rabbitmq-fs2/target modules/db-skunk/target modules/db-migration-tests/target modules/http-client-tests/target modules/db-doobie/target modules/docs/target modules/db-doobie-tests/target modules/core/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         run: tar cf targets.tar modules/redis-rediculous/target modules/core-tests/target modules/redis-rediculous-tests/target modules/db-migration/target modules/example/target modules/flags/target modules/http-client/target modules/rabbitmq-fs2-tests/target modules/db-skunk-tests/target modules/rabbitmq-fs2/target modules/db-skunk/target modules/db-migration-tests/target modules/http-client-tests/target modules/db-doobie/target modules/docs/target modules/db-doobie-tests/target modules/core/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
@@ -90,7 +90,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [prepare-release]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ To use the latest version, include the following in your `build.sbt`:
 [source,scala]
 --
 libraryDependencies ++= Seq(
-  "com.rlemaitre" %% "pillars" % "@VERSION@"
+  "io.funktional" %% "pillars" % "@VERSION@"
 )
 --
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import xerial.sbt.Sonatype.GitHubHosting
+import xerial.sbt.Sonatype.sonatypeCentralHost
 
 ThisBuild / tlBaseVersion := "0.4" // your current series x.y
 
@@ -11,7 +12,7 @@ ThisBuild / developers ++= List(
   tlGitHubDev("rlemaitre", "Raphaël Lemaitre")
 )
 
-//ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 ThisBuild / sonatypeProjectHosting := Some(GitHubHosting(
   "FunktionalIO",
   "pillars",

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import xerial.sbt.Sonatype.GitHubHosting
 
 ThisBuild / tlBaseVersion := "0.4" // your current series x.y
 
-ThisBuild / organization := "com.rlemaitre"
+ThisBuild / organization := "io.funktional"
 ThisBuild / homepage     := Some(url("https://pillars.dev"))
 ThisBuild / startYear    := Some(2023)
 ThisBuild / licenses     := Seq("EPL-2.0" -> url("https://www.eclipse.org/legal/epl-2.0/"))
@@ -266,7 +266,7 @@ lazy val pillars = project
         version.value,
         "-project-logo",
         "modules/docs/src/docs/images/logo.png",
-        //    "-source-links:github://rlemaitre/pillars",
+        //    "-source-links:github://FunktionalIO/pillars",
         "-social-links:github::https://github.com/FunktionalIO/pillars"
       ),
       unusedCompileDependenciesFilter -= moduleFilter("org.typelevel", "scalac-compat-annotation")

--- a/modules/docs/src/docs/contribute/10_contributing.adoc
+++ b/modules/docs/src/docs/contribute/10_contributing.adoc
@@ -32,7 +32,7 @@ There are other easy ways to support the project and show your appreciation, whi
 === Code of Conduct
 
 This project and everyone participating in it is governed by the
-link:https://github.com/rlemaitre/pillarsblob/master/CODE_OF_CONDUCT.md[Pillars Code of Conduct].
+link:https://github.com/FunktionalIO/pillars/blob/master/CODE_OF_CONDUCT.md[Pillars Code of Conduct].
 By participating, you are expected to uphold this code.
 Please report unacceptable behavior to mailto:pillars@pillars.dev[].
 
@@ -43,13 +43,13 @@ Please report unacceptable behavior to mailto:pillars@pillars.dev[].
 [NOTE]
 If you want to ask a question, we assume that you have read the available link:https://pillars.dev[Documentation].
 
-Before you ask a question, it is best to search for existing link:https://github.com/rlemaitre/pillars/issues[Issues] that might help you.
+Before you ask a question, it is best to search for existing link:https://github.com/FunktionalIO/pillars/issues[Issues] that might help you.
 In case you have found a suitable issue and still need clarification, you can write your question in this issue.
 It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-* Open an https://github.com/rlemaitre/pillars/issues/new[Issue].
+* Open an https://github.com/FunktionalIO/pillars/issues/new[Issue].
 * Provide as much context as you can about what you're running into.
 * Provide project and platform versions (scala, sbt, etc), depending on what seems relevant.
 
@@ -70,7 +70,7 @@ Please complete the following steps in advance to help us fix any potential bug 
 
 * Make sure that you are using the latest version.
 * Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the link:https://pillars.dev[documentation]. If you are looking for support, you might want to check <<i-have-a-question, this section>>.
-* To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the link:https://github.com/rlemaitre/pillarsissues?q=label%3Abug[bug tracker].
+* To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the link:https://github.com/FunktionalIO/pillars/issues?q=label%3Abug[bug tracker].
 * Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 * Collect information about the bug:
 * Stack trace (Traceback)
@@ -88,7 +88,7 @@ Instead, sensitive bugs must be sent by email to mailto:security@pillars.dev[].
 We use GitHub issues to track bugs and errors.
 If you run into an issue with the project:
 
-* Open an link:https://github.com/rlemaitre/pillars/issues/new[Issue].
+* Open an link:https://github.com/FunktionalIO/pillars/issues/new[Issue].
 (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 * Explain the behavior you would expect and the actual behavior.
 * Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own.
@@ -114,7 +114,7 @@ Following these guidelines will help maintainers and the community to understand
 
 * Make sure that you are using the latest version.
 * Read the link:https://pillars.pillars.dev[documentation] carefully and find out if the functionality is already covered, maybe by an individual configuration.
-* Perform a link:https://github.com/rlemaitre/pillars/issues[search] to see if the enhancement has already been suggested.
+* Perform a link:https://github.com/FunktionalIO/pillars/issues[search] to see if the enhancement has already been suggested.
 If it has, add a comment to the existing issue instead of opening a new one.
 * Find out whether your idea fits with the scope and aims of the project.
 It's up to you to make a strong case to convince the project's developers of the merits of this feature.
@@ -123,7 +123,7 @@ If you're just targeting a minority of users, consider writing an add-on/plugin 
 
 ===== How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as link:https://github.com/rlemaitre/pillars/issues[GitHub issues].
+Enhancement suggestions are tracked as link:https://github.com/FunktionalIO/pillars/issues[GitHub issues].
 
 * Use a *clear and descriptive title* for the issue to identify the suggestion.
 * Provide a *step-by-step description of the suggested enhancement* in as many details as possible.

--- a/modules/docs/src/docs/user-guide/10_quick-start.adoc
+++ b/modules/docs/src/docs/user-guide/10_quick-start.adoc
@@ -25,7 +25,7 @@ To use the latest version, include the following in your `build.sbt`:
 [source,sbt,subs="+attributes"]
 --
 libraryDependencies ++= Seq(
-  "com.rlemaitre" %% "pillars-core" % "{site_version}"
+  "io.funktional" %% "pillars-core" % "{site_version}"
 )
 --
 
@@ -34,10 +34,10 @@ You can also add optional modules to your dependencies:
 [source,sbt,subs="+attributes"]
 --
 libraryDependencies ++= Seq(
-  "com.rlemaitre" %% "pillars-db" % "{site_version}",
-  "com.rlemaitre" %% "pillars-db-migration" % "{site_version}",
-  "com.rlemaitre" %% "pillars-flags" % "{site_version}",
-  "com.rlemaitre" %% "pillars-http-client" % "{site_version}"
+  "io.funktional" %% "pillars-db" % "{site_version}",
+  "io.funktional" %% "pillars-db-migration" % "{site_version}",
+  "io.funktional" %% "pillars-flags" % "{site_version}",
+  "io.funktional" %% "pillars-http-client" % "{site_version}"
 )
 --
 

--- a/modules/docs/src/site/assets/humans.txt
+++ b/modules/docs/src/site/assets/humans.txt
@@ -2,7 +2,7 @@
 Creator: Raphaël Lemaitre
 Site: https://rlemaitre.com
 Contact: contact [at] rlemaitre [dot] com
-Twitter: @rlemaitre
+Bluesky: @rlemaitre.com
 Location: Paris, France
 
 /* THANKS */

--- a/modules/docs/src/site/doc/landingpage.gsp
+++ b/modules/docs/src/site/doc/landingpage.gsp
@@ -43,18 +43,18 @@ end app
                 <li class="tab" data-tab="maven">Maven</li>
             </ul>
             <pre class="code tab__pane active sbt">
-                <code class="highlight language-scala">libraryDependencies ++= Seq("com.rlemaitre" %% "pillars-core" % "${config.site_version}")</code>
+                <code class="highlight language-scala">libraryDependencies ++= Seq("io.funktional" %% "pillars-core" % "${config.site_version}")</code>
             </pre>
             <pre class="code tab__pane mill">
-                <code class="highlight language-scala">ivy"com.rlemaitre::pillars-core:${config.site_version}"</code>
+                <code class="highlight language-scala">ivy"io.funktional::pillars-core:${config.site_version}"</code>
             </pre>
             <pre class="code tab__pane scala-cli">
-                <code class="highlight language-scala">//> using dep com.rlemaitre::pillars-core:${config.site_version}</code>
+                <code class="highlight language-scala">//> using dep io.funktional::pillars-core:${config.site_version}</code>
             </pre>
             <pre class="code tab__pane pants">
                 <code class="highlight language-scala">
 scala_artifact(
-    group="com.rlemaitre",
+    group="io.funktional",
     artifact="pillars-core",
     version="${config.site_version}",
     packages=["pillars.**"],
@@ -62,12 +62,12 @@ scala_artifact(
                 </code>
             </pre>
             <pre class="code tab__pane gradle">
-                <code class="highlight language-gradle">implementation 'com.rlemaitre:pillars-core:${config.site_version}'</code>
+                <code class="highlight language-gradle">implementation 'io.funktional:pillars-core:${config.site_version}'</code>
             </pre>
             <pre class="code tab__pane maven">
                 <code class="highlight language-xml">
 &lt;dependency>
-    &lt;groupId>com.rlemaitre&lt;/groupId>
+    &lt;groupId>io.funktional&lt;/groupId>
     &lt;artifactId>pillars-core&lt;/artifactId>
     &lt;version>${config.site_version}&lt;/version>
 &lt;/dependency>

--- a/modules/docs/src/site/templates/header.gsp
+++ b/modules/docs/src/site/templates/header.gsp
@@ -27,7 +27,7 @@
     <meta content="Pillars" itemprop="name">
     <meta content="Build your backend service in Scala 3 the easy way" itemprop="description">
     <meta content="summary" name="twitter:card">
-    <meta content="@rlemaitre" name="twitter:creator">
+    <meta content="@rlemaitre.com" name="twitter:creator">
     <meta content="Pillars" name="twitter:title">
     <meta content="Build your backend service in Scala 3 the easy way" name="twitter:description">
     <meta property="og:url" content="https://pillars.dev/" />

--- a/modules/docs/src/site/templates/menu.gsp
+++ b/modules/docs/src/site/templates/menu.gsp
@@ -22,7 +22,7 @@
         }
 %>
         <li class="menu__item"><a href="${content.rootpath}api/" class="link link--dark"><i class="fa fa-cogs"></i> API</a></li>
-        <li class="menu__item"><a href="https://github.com/rlemaitre/pillars/" class="link link--dark"><i class="fa fa-github"></i> Github</a></li>
+        <li class="menu__item"><a href="https://github.com/FunktionalIO/pillars/" class="link link--dark"><i class="fa fa-github"></i> Github</a></li>
         <li class="menu__item">
             <form action="${content.rootpath}search.html">
             <input aria-label="Search this site…" autocomplete="off" class="form-control td-search-input"

--- a/modules/docs/src/site/templates/page.gsp
+++ b/modules/docs/src/site/templates/page.gsp
@@ -10,7 +10,7 @@
 	<article class="doc__content">
 		<%include "main.gsp"%>
     <script src="https://giscus.app/client.js"
-            data-repo="rlemaitre/pillars"
+            data-repo="FunktionalIO/pillars"
             data-repo-id="R_kgDOK-Le0g"
             data-category="Comments"
             data-category-id="DIC_kwDOK-Le0s4Ccs4S"

--- a/modules/docs/src/site/templates/page_menu.gsp
+++ b/modules/docs/src/site/templates/page_menu.gsp
@@ -24,7 +24,7 @@
         }
 %>
         <li class="menu__item"><a href="${content.rootpath}api/" class="link link--dark"><i class="fa fa-cogs"></i> API</a></li>
-        <li class="menu__item"><a href="https://github.com/rlemaitre/pillars/" class="link link--dark"><i class="fa fa-github"></i> Github</a></li>
+        <li class="menu__item"><a href="https://github.com/FunktionalIO/pillars/" class="link link--dark"><i class="fa fa-github"></i> Github</a></li>
         <li class="menu__item">
             <form action="${content.rootpath}search.html">
                 <input aria-label="Search this site…" autocomplete="off" class="form-control td-search-input"


### PR DESCRIPTION
As a following to the Github organisation change, artifacts are now published in the `io.funktional` namespace.

BREAKING CHANGE: users will need to modify their dependencies to io.funktional