### PR TITLE
feat!: migrate from tagless final to IO-based implementation

### DIFF
--- a/modules/core-tests/src/main/scala/pillars/tests/ModuleTestSupport.scala
+++ b/modules/core-tests/src/main/scala/pillars/tests/ModuleTestSupport.scala
@@ -4,15 +4,12 @@
 
 package pillars.tests
 
-import cats.effect.Async
+import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.std.Console
 import com.dimafeng.testcontainers.Container
-import fs2.io.net.Network
-import org.typelevel.otel4s.trace.Tracer
 import pillars.Module
 
 trait ModuleTestSupport:
     def key: Module.Key
-    def load[F[_]: Async: Network: Tracer: Console](container: Container): Option[Resource[F, Module[F[_]]]]
+    def load(container: Container): Option[Resource[IO, Module]]
 end ModuleTestSupport

--- a/modules/core-tests/src/main/scala/pillars/tests/suite.scala
+++ b/modules/core-tests/src/main/scala/pillars/tests/suite.scala
@@ -15,7 +15,6 @@ import com.dimafeng.testcontainers.munit.*
 import io.circe.Decoder
 import io.github.iltotore.iron.*
 import munit.CatsEffectSuite
-import org.typelevel.otel4s.trace.Tracer
 import pillars.AdminServer
 import pillars.ApiServer
 import pillars.App
@@ -31,7 +30,7 @@ import scribe.Scribe
 trait PillarsSuite extends CatsEffectSuite, TestContainersSuite:
     def moduleSupports: Set[ModuleTestSupport]
 
-    def withPillars[T](test: Pillars[IO] => IO[T]): IO[T] =
+    def withPillars[T](test: Pillars => IO[T]): IO[T] =
         withContainers: container =>
             extractContainers(container) match
                 case Left(error)       => fail(error)
@@ -40,7 +39,7 @@ trait PillarsSuite extends CatsEffectSuite, TestContainersSuite:
                         test(p)
 
     def fromContainer(supports: Set[ModuleTestSupport])(containers: List[? <: SingleContainer[?]])
-        : Resource[IO, Pillars[IO]] =
+        : Resource[IO, Pillars] =
         val conf = PillarsConfig(
           name = App.Name("Tests"),
           api = ApiServer.Config(enabled = false),
@@ -48,20 +47,19 @@ trait PillarsSuite extends CatsEffectSuite, TestContainersSuite:
           observability = Observability.Config()
         )
         for
-            obs     <- Observability.noop[IO].toResource
+            obs     <- Observability.noop.toResource
             modules <-
-                given Tracer[IO] = obs.tracer
                 (for
                     container <- containers
                     support   <- supports
-                    modules   <- support.load[IO](container)
+                    modules   <- support.load(container)
                     pair       = modules.map(support.key -> _)
                 yield pair).sequence.map(mods => Modules(mods.toMap))
         yield new Pillars:
             override def appInfo: AppInfo                                = BuildInfo.toAppInfo
-            override def observability: Observability[IO]                = obs
+            override def observability: Observability                    = obs
             override def config: PillarsConfig                           = conf
-            override def apiServer: ApiServer[IO]                        = ApiServer.noop[IO]
+            override def apiServer: ApiServer                            = ApiServer.noop
             override def logger: Scribe[IO]                              = scribe.cats.io
             override def readConfig[T](using decoder: Decoder[T]): IO[T] =
                 IO.raiseError(new NotImplementedError("readConfig is not available in tests"))

--- a/modules/core/src/main/scala/pillars/AdminServer.scala
+++ b/modules/core/src/main/scala/pillars/AdminServer.scala
@@ -4,9 +4,8 @@
 
 package pillars
 
-import cats.effect.Async
+import cats.effect.IO
 import cats.effect.Resource.ExitCase
-import cats.effect.kernel.Async
 import cats.syntax.all.*
 import com.comcast.ip4s.*
 import io.circe.Codec
@@ -15,14 +14,14 @@ import pillars.AdminServer.Config
 import sttp.model.StatusCode
 import sttp.tapir.*
 
-final case class AdminServer[F[_]: Async](
+final case class AdminServer(
     config: Config,
     infos: AppInfo,
-    obs: Observability[F],
-    controllers: List[Controller[F]]
+    obs: Observability,
+    controllers: List[Controller]
 ):
-    def start(): F[Unit] =
-        val logger = scribe.cats.effect[F]
+    def start(): IO[Unit] =
+        val logger = scribe.cats.io
         import logger.*
         if config.enabled then
             for
@@ -41,7 +40,7 @@ final case class AdminServer[F[_]: Async](
                              case _                   => info("Admin server stopped")
                          .useForever
             yield ()
-        else Async[F].unit
+        else IO.unit
         end if
     end start
 end AdminServer

--- a/modules/core/src/main/scala/pillars/Controller.scala
+++ b/modules/core/src/main/scala/pillars/Controller.scala
@@ -4,10 +4,11 @@
 
 package pillars
 
+import cats.effect.IO
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.server.ServerEndpoint
 
-type Controller[F[_]] = List[Controller.HttpEndpoint[F]]
+type Controller = List[Controller.HttpEndpoint]
 
 object Controller:
-    type HttpEndpoint[F[_]] = ServerEndpoint[Fs2Streams[F], F]
+    type HttpEndpoint = ServerEndpoint[Fs2Streams[IO], IO]

--- a/modules/core/src/main/scala/pillars/modules.scala
+++ b/modules/core/src/main/scala/pillars/modules.scala
@@ -4,20 +4,17 @@
 
 package pillars
 
-import cats.effect.Async
+import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.std.Console
-import fs2.io.net.Network
-import org.typelevel.otel4s.trace.Tracer
 import pillars.Config.Reader
 import pillars.probes.Probe
 import scribe.Scribe
 
-trait Module[F[_]]:
+trait Module:
     type ModuleConfig <: Config
-    def probes: List[Probe[F]] = Nil
+    def probes: List[Probe] = Nil
 
-    def adminControllers: List[Controller[F]] = Nil
+    def adminControllers: List[Controller] = Nil
 
     def config: ModuleConfig
 
@@ -31,34 +28,31 @@ object Module:
     end Key
 end Module
 
-case class Modules[F[_]](private val values: Map[Module.Key, Module[F]]):
-    def add[K <: Module[F]](key: Module.Key)(value: K): Modules[F] = Modules(values + (key -> value))
-    def get[K](key: Module.Key): K                                 = values(key).asInstanceOf[K]
+case class Modules(private val values: Map[Module.Key, Module]):
+    def add[K <: Module](key: Module.Key)(value: K): Modules = Modules(values + (key -> value))
+    def get[K](key: Module.Key): K                           = values(key).asInstanceOf[K]
     export values.size
     export values.values as all
-    def probes: List[Probe[F]]                                     = all.flatMap(_.probes).toList
-    def adminControllers: List[Controller[F]]                      = all.flatMap(_.adminControllers).toList
+    def probes: List[Probe]                                  = all.flatMap(_.probes).toList
+    def adminControllers: List[Controller]                   = all.flatMap(_.adminControllers).toList
 end Modules
 object Modules:
-    def empty[F[_]]: Modules[F] = Modules(Map.empty)
+    def empty: Modules = Modules(Map.empty)
 
 trait ModuleSupport:
-    type M[F[_]] <: Module[F]
+    type M <: Module
     def key: Module.Key
 
     def dependsOn: Set[ModuleSupport] = Set.empty
 
-    def load[F[_]: Async: Network: Tracer: Console](
-        context: ModuleSupport.Context[F],
-        modules: Modules[F] = Modules.empty
-    ): Resource[F, M[F]]
+    def load(context: ModuleSupport.Context, modules: Modules = Modules.empty): Resource[IO, M]
 
 end ModuleSupport
 
 object ModuleSupport:
-    final case class Context[F[_]: Async: Network: Tracer: Console](
-        observability: Observability[F],
-        reader: Reader[F],
-        logger: Scribe[F]
+    final case class Context(
+        observability: Observability,
+        reader: Reader,
+        logger: Scribe[IO]
     )
 end ModuleSupport

--- a/modules/core/src/main/scala/pillars/package.scala
+++ b/modules/core/src/main/scala/pillars/package.scala
@@ -5,7 +5,6 @@
 package pillars
 
 import cats.data.Validated
-import cats.effect.IO
 import com.monovore.decline.Argument
 import fs2.io.file.Path
 
@@ -15,11 +14,8 @@ given Argument[Path] with
     def defaultMetavar = "path"
 
 /**
- * Type alias for a Pillars[F] context bound.
+ * Type alias for a Pillars context bound.
  *
- * @tparam F The effect type.
  * @tparam A The type of the value that is being computed.
  */
-type Run[F[_], A] = Pillars[F] ?=> A
-
-type RunIO[A] = Run[IO, A]
+type Run[A] = Pillars ?=> A

--- a/modules/db-doobie-tests/src/main/scala/pillars/db_doobie/tests/DB.scala
+++ b/modules/db-doobie-tests/src/main/scala/pillars/db_doobie/tests/DB.scala
@@ -4,13 +4,10 @@
 
 package pillars.db_doobie.tests
 
-import cats.effect.Async
+import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.std.Console
 import com.dimafeng.testcontainers.JdbcDatabaseContainer
-import fs2.io.net.Network
 import io.github.iltotore.iron.*
-import org.typelevel.otel4s.trace.Tracer
 import pillars.Config.Secret
 import pillars.Module
 import pillars.Modules
@@ -19,14 +16,12 @@ import pillars.db_doobie.*
 import pillars.probes.ProbeConfig
 
 case class DB(container: JdbcDatabaseContainer) extends ModuleSupport:
-    override type M[F[_]] = pillars.db_doobie.DB[F]
+    override type M = pillars.db_doobie.DB
 
     override def key: Module.Key = pillars.db_doobie.DB.key
 
-    override def load[F[_]: Async: Network: Tracer: Console](
-        context: ModuleSupport.Context[F],
-        modules: Modules[F]
-    ): Resource[F, pillars.db_doobie.DB[F]] = pillars.db_doobie.DB.load[F](dbConfig)
+    override def load(context: ModuleSupport.Context, modules: Modules): Resource[IO, pillars.db_doobie.DB] =
+        pillars.db_doobie.DB.load(dbConfig)
 
     private def dbConfig: DatabaseConfig =
         DatabaseConfig(

--- a/modules/db-migration/src/test/scala/pillars/db/migration/MigrationTests.scala
+++ b/modules/db-migration/src/test/scala/pillars/db/migration/MigrationTests.scala
@@ -8,7 +8,6 @@ import cats.effect.IO
 import com.dimafeng.testcontainers.PostgreSQLContainer
 import io.github.iltotore.iron.*
 import org.testcontainers.utility.DockerImageName
-import org.typelevel.otel4s.trace.Tracer
 import pillars.Config.Secret
 import pillars.Pillars
 import pillars.db.DatabaseConfig
@@ -42,10 +41,9 @@ class MigrationTests extends PillarsFromContainerForEach:
 
     test("migration should run the scripts"):
         withPillars: p =>
-            given Pillars[IO]           = p
-            given Tracer[IO]            = p.observability.tracer
-            val config: MigrationConfig = configFor(p.module[pillars.db.DB[IO]](DB.key).config)
-            val migration               = DBMigration[IO](config)
+            given Pillars               = p
+            val config: MigrationConfig = configFor(p.module[pillars.db.DB](DB.key).config)
+            val migration               = DBMigration(config)
             val result                  =
                 for
                     _   <- migration.migrate("db/migrations")
@@ -56,10 +54,9 @@ class MigrationTests extends PillarsFromContainerForEach:
 
     test("migration should write in the history table"):
         withPillars: p =>
-            given Pillars[IO]           = p
-            given Tracer[IO]            = p.observability.tracer
-            val config: MigrationConfig = configFor(p.module[pillars.db.DB[IO]](DB.key).config)
-            val migration               = DBMigration[IO](config)
+            given Pillars               = p
+            val config: MigrationConfig = configFor(p.module[pillars.db.DB](DB.key).config)
+            val migration               = DBMigration(config)
             val result                  =
                 for
                     _   <- migration.migrate("db/migrations", DatabaseSchema.public, DatabaseTable("schema_history"))
@@ -70,10 +67,9 @@ class MigrationTests extends PillarsFromContainerForEach:
 
     test("running twice migrations should be the same as running once"):
         withPillars: p =>
-            given Pillars[IO]           = p
-            given Tracer[IO]            = p.observability.tracer
-            val config: MigrationConfig = configFor(p.module[pillars.db.DB[IO]](DB.key).config)
-            val migration               = DBMigration[IO](config)
+            given Pillars               = p
+            val config: MigrationConfig = configFor(p.module[pillars.db.DB](DB.key).config)
+            val migration               = DBMigration(config)
             val result                  =
                 for
                     _   <- migration.migrate("db/migrations")

--- a/modules/db-skunk-tests/src/main/scala/pillars/db/tests/DB.scala
+++ b/modules/db-skunk-tests/src/main/scala/pillars/db/tests/DB.scala
@@ -4,15 +4,13 @@
 
 package pillars.db.tests
 
-import cats.effect.Async
+import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.std.Console
 import cats.syntax.all.*
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.Port
 import com.dimafeng.testcontainers.Container
 import com.dimafeng.testcontainers.PostgreSQLContainer
-import fs2.io.net.Network
 import io.github.iltotore.iron.*
 import org.typelevel.otel4s.trace.Tracer
 import pillars.Config.Secret
@@ -27,10 +25,12 @@ import pillars.tests.ModuleTestSupport
 object DB extends ModuleTestSupport:
     override def key: Module.Key = DBModule.key
 
-    def load[F[_]: Async: Network: Tracer: Console](container: Container): Option[Resource[F, Module[F]]] =
+    def load(container: Container): Option[Resource[IO, Module]] =
+        given Tracer[IO] = Tracer.noop
         container match
             case c: PostgreSQLContainer => DBModule.load(configFor(c)).some
             case _                      => None
+    end load
 
     private def configFor(container: PostgreSQLContainer): DatabaseConfig =
         DatabaseConfig(

--- a/modules/docs/src/docs/user-guide/10_quick-start.adoc
+++ b/modules/docs/src/docs/user-guide/10_quick-start.adoc
@@ -60,7 +60,7 @@ include::{projectRootDir}/modules/example/src/main/scala/example/app.scala[tag=q
 It is used by the admin server to display information about your application.
 See <<Application Metadata>> for more information.
 <3> The `run` is the entry point of your application.
-Thanks to the `Run[F[_], T]` context function, you have access to a `Pillars[F]` instance that contains all your modules.
+Thanks to the `Run[T]` context function, you have access to a `Pillars` instance that contains all your modules.
 <4> Each module is accessible through the `Pillars` instance or through a top-level function in the module's package.
 The `dbMigration.migrate` function is a top-level function that is provided by the `db-migration` module.
 <5> The API server must be started with the `server.start` function with the controllers you want to expose.
@@ -112,7 +112,7 @@ $ curl http://localhost:19876/admin/probes/health | jq
 
 === Application Metadata
 
-The `infos` property of the `App[F]` trait defines some metadata about your application.
+The `infos` property of the `App` trait defines some metadata about your application.
 You have two ways of defining it:
 
 You can directly create an instance of `AppInfo`:
@@ -156,5 +156,5 @@ Then, you can use the `BuildInfo` object in your application:
 import example.build.BuildInfo
 
   override val infos = BuildInfo.toAppInfo
-  override def run(): Run[IO, IO[Unit]] = ???
+  override def run(): Run[IO[Unit]] = ???
 ----

--- a/modules/docs/src/docs/user-guide/20_features/10_configuration.adoc
+++ b/modules/docs/src/docs/user-guide/20_features/10_configuration.adoc
@@ -193,7 +193,7 @@ object app extends pillars.EntryPoint:
     def app: pillars.App[IO] = new pillars.App[IO]:
         def infos: AppInfo = BuildInfo.toAppInfo
 
-        def run(using p: Pillars[IO]): IO[Unit] =
+        def run(using p: Pillars): IO[Unit] =
             import p.*
             for
                 config <- configReader[BookstoreConfig]

--- a/modules/docs/src/docs/user-guide/20_features/20_logging.adoc
+++ b/modules/docs/src/docs/user-guide/20_features/20_logging.adoc
@@ -24,7 +24,8 @@ To log something in your code, you can use the `logger` defined in the `pillars`
 
 [source,scala]
 ----
-def run(using Pillars[IO]): IO[Unit] =
+import pillars.Pillars.logger
+def run(using Pillars): IO[Unit] =
     for
         _ <- logger.info(s"📚 Welcome to ${config.name}!")
         _ <- logger.debug(s"📚 The configuration is: $config")

--- a/modules/docs/src/docs/user-guide/30_modules/10_db.adoc
+++ b/modules/docs/src/docs/user-guide/30_modules/10_db.adoc
@@ -83,7 +83,7 @@ For Skunk:
 import pillars.db.*
 import skunk.*
 
-def foo[F[_]](using Pillars[F]) =
+def foo(using Pillars[F]) =
     sessions.use: session =>
         session.unique(sql"SELECT 1".query[Int])
 --
@@ -94,7 +94,7 @@ For Doobie:
 import pillars.db_doobie.*
 import doobie.*
 
-def foo[F[_]](using Pillars[F]) =
+def foo(using Pillars) =
     sql"SELECT 1".query[Int].unique.transact(db.transactor)
 --
 
@@ -104,7 +104,7 @@ The `DB` module provides a xref:../20_features/30_probes.adoc[probe] for health 
 
 [source,scala,linenums,role="data-noescape"]
 --
-val isHealthy: F[Boolean] = dbModule.probes.head.check
+val isHealthy: IO[Boolean] = dbModule.probes.head.check
 --
 
 This will return a boolean indicating whether the database is healthy or not.

--- a/modules/docs/src/docs/user-guide/30_modules/15_db-migration.adoc
+++ b/modules/docs/src/docs/user-guide/30_modules/15_db-migration.adoc
@@ -47,5 +47,5 @@ The migration files must be named in the following format: `V\{version}__{descri
 
 The migration files are executed in the order of their version.
 
-To execute the migrations, you can use the `migrate` method of the `DBMigration[F]` class.
-The `DBMigration[F]` object can be obtained via the `dbMigrations` access method having a `Pillars[F]` instance in scope.
+To execute the migrations, you can use the `migrate` method of the `DBMigration` class.
+The `DBMigration` object can be obtained via the `dbMigrations` access method having a `Pillars` instance in scope.

--- a/modules/docs/src/docs/user-guide/30_modules/20_http-client.adoc
+++ b/modules/docs/src/docs/user-guide/30_modules/20_http-client.adoc
@@ -33,31 +33,31 @@ To use the `HttpClient` module, you need to import it and then access it using t
 --
 import pillars.httpclient.*
 
-http.get("some.uri.com") // with a `Pillars[IO]` in scope
+http.get("some.uri.com") // with a `Pillars` in scope
 --
 
 === HTTP Operations
 
 The `HttpClient` module provides methods for sending HTTP requests and receiving HTTP responses.
-You can use the `httpClient` extension method on `Pillars` to get an instance of `Client[F]`:
+You can use the `httpClient` extension method on `Pillars` to get an instance of `Client[IO]`:
 
 [source,scala,linenums,role="data-noescape"]
 --
 import org.http4s.client.Client
 
-val client: Client[F] = http.client
+val client: Client[IO] = http.client
 --
 
-This `Client[F]` instance can be used to send HTTP requests by using the same methods as `org.http4s.client.Client[F]`.
+This `Client[IO]` instance can be used to send HTTP requests by using the same methods as `org.http4s.client.Client[IO]`.
 
-In addition to `org.http4s.client.Client[F]` methods, the `HttpClient` module provides methods to directly call a tapir endpoint:
+In addition to `org.http4s.client.Client[IO]` methods, the `HttpClient` module provides methods to directly call a tapir endpoint:
 
 * `call`: Calls a tapir public endpoint with the specified input and returns either the output or the error output.
 * `callSecure`: Calls a tapir secure endpoint with the specified input and security input and returns either the output or the error output.
 
 [source,scala,linenums]
 --
-val client = Pillars[F].httpClient
+val client = Pillars.httpClient
 val public: PublicEndpoint[Input, ErrorOutput, Output, Capabilities] = ???
 val secure: Endpoint[SecurityInput, Input, ErrorOutput, Output, Capabilities] = ???
 
@@ -65,8 +65,8 @@ val uri: Option[Uri] = ???
 val input: Input = ???
 val securityInput: SecurityInput = ???
 
-val output: F[Either[ErrorOutput, Output]] = client.call(public, uri)(input)
-val secureOutput: F[Either[ErrorOutput, Output]] = client.callSecure(secure)(securityInput, input)
+val output: IO[Either[ErrorOutput, Output]] = client.call(public, uri)(input)
+val secureOutput: IO[Either[ErrorOutput, Output]] = client.callSecure(secure)(securityInput, input)
 --
 
 If an infrastructure error occurs, a `HttpClient.Error` will be thrown on the error channel.

--- a/modules/docs/src/docs/user-guide/30_modules/40_redis.adoc
+++ b/modules/docs/src/docs/user-guide/30_modules/40_redis.adoc
@@ -28,10 +28,10 @@ To use the `Redis` module, you need to import it and then access it through the 
 --
 import pillars.redis.*
 
-val redisModule = pillarsInstance.redis
+val redisModule = Pillars.redis
 --
 
-You can also use directly `Redis[F]`
+You can also use directly `Redis`
 You can then use the `redisModule` to perform Redis operations.
 
 === Redis Operations

--- a/modules/docs/src/docs/user-guide/30_modules/41_rabbitmq.adoc
+++ b/modules/docs/src/docs/user-guide/30_modules/41_rabbitmq.adoc
@@ -49,10 +49,10 @@ To use the `RabbitMQ` module, you need to import it and then access it through t
 --
 import pillars.redis.*
 
-val rabbitmqModule = pillarsInstance.redis
+val rabbitmqModule = pillars.redis
 --
 
-You can also use directly `RabbitMQ[F]`.
+You can also use directly `RabbitMQ`.
 You can then use the `rabbitmqModule` to perform RabbitMQ operations.
 
 === RabbitMQ Operations
@@ -62,7 +62,7 @@ You can then use the `rabbitmqModule` to perform RabbitMQ operations.
 import pillars.redis.*
 
 for
-    client <- RabbitMQ[IO](configFor(container)).map(_.client)
+    client <- RabbitMQ(configFor(container)).map(_.client)
     _      <- client.createConnectionChannel.evalMap: implicit channel =>
                   for
                       publisher  <- client.createPublisher[String](exchange, routingKey)

--- a/modules/example/src/main/scala/example/app.scala
+++ b/modules/example/src/main/scala/example/app.scala
@@ -20,7 +20,7 @@ import skunk.implicits.*
 object app extends pillars.IOApp(DB, DBMigration, FeatureFlags, HttpClient): // // <1>
     def infos: AppInfo = BuildInfo.toAppInfo // // <2>
 
-    def run: Run[IO, IO[Unit]] = // // <3>
+    def run: Run[IO[Unit]] = // // <3>
         for
             _ <- logger.info(s"📚 Welcome to ${config.name}!")
             _ <- dbMigration.migrate("classpath:db-migrations") // // <4>

--- a/modules/example/src/main/scala/example/controllers.scala
+++ b/modules/example/src/main/scala/example/controllers.scala
@@ -13,31 +13,31 @@ import pillars.db.*
 import pillars.logger
 import skunk.implicits.sql
 
-def homeController(using p: Pillars[IO]): Controller[IO] =
-    def ping: HttpEndpoint[IO] = Endpoints.ping.serverLogicSuccess: _ =>
+def homeController(using p: Pillars): Controller =
+    def ping: HttpEndpoint = Endpoints.ping.serverLogicSuccess: _ =>
         p.observability.tracer.span("ping").surround:
             "pong".pure[IO]
-    def boom: HttpEndpoint[IO] = Endpoints.boom.serverLogic: _ =>
+    def boom: HttpEndpoint = Endpoints.boom.serverLogic: _ =>
         throw new RuntimeException("💣 boom")
 
     List(ping, boom)
 end homeController
 
-def userController(using Pillars[IO]): Controller[IO] =
-    def list: HttpEndpoint[IO] = Endpoints.listUser.serverLogic: _ =>
+def userController(using Pillars): Controller =
+    def list: HttpEndpoint = Endpoints.listUser.serverLogic: _ =>
         Left(errors.api.NotImplemented.view).pure[IO]
 
-    def create: HttpEndpoint[IO] = Endpoints.createUser.serverLogic: user =>
+    def create: HttpEndpoint = Endpoints.createUser.serverLogic: user =>
         sessions.use: session =>
             for
                 completion <- session.execute(db.users.createUser)(user.toModel)
                 _          <- logger.debug(s"Create user resulted in $completion.")
             yield Right(user)
 
-    def get: HttpEndpoint[IO] = Endpoints.getUser.serverLogic: _ =>
+    def get: HttpEndpoint = Endpoints.getUser.serverLogic: _ =>
         Left(errors.api.NotImplemented.view).pure[IO]
 
-    def delete: HttpEndpoint[IO] = Endpoints.deleteUser.serverLogic: _ =>
+    def delete: HttpEndpoint = Endpoints.deleteUser.serverLogic: _ =>
         Left(errors.api.NotImplemented.view).pure[IO]
 
     List(list, create, get, delete)

--- a/modules/flags/src/main/scala/pillars/flags/FlagController.scala
+++ b/modules/flags/src/main/scala/pillars/flags/FlagController.scala
@@ -4,7 +4,6 @@
 
 package pillars.flags
 
-import cats.Functor
 import cats.syntax.all.*
 import io.github.iltotore.iron.*
 import pillars.AdminServer.baseEndpoint
@@ -20,7 +19,7 @@ import sttp.tapir.*
 import sttp.tapir.codec.iron.given
 import sttp.tapir.json.circe.jsonBody
 
-def flagController[F[_]: Functor](manager: FeatureFlags[F]): Controller[F] =
+def flagController(manager: FeatureFlags): Controller =
     val listAll = FlagEndpoints.list.serverLogicSuccess(_ => manager.flags)
     val getOne  =
         FlagEndpoints.get.serverLogic: name =>

--- a/modules/flags/src/main/scala/pillars/flags/package.scala
+++ b/modules/flags/src/main/scala/pillars/flags/package.scala
@@ -4,6 +4,7 @@
 
 package pillars
 
+import cats.effect.IO
 import io.circe.Codec
 import io.circe.Decoder
 import io.circe.Encoder
@@ -31,11 +32,11 @@ package object flags:
     given Codec[FeatureFlag] = Codec.AsObject.derived
 
     given Schema[FeatureFlag] = Schema.derived
-    extension [F[_]](p: Pillars[F])
-        def flags: FeatureFlags[F] = p.module(FeatureFlags.Key)
+    extension (p: Pillars)
+        def flags: FeatureFlags = p.module(FeatureFlags.Key)
 
-        def whenEnabled[A](flag: Flag)(thunk: => F[A]): F[Unit] =
-            p.module[FeatureFlags[F]](FeatureFlags.Key).when(flag)(thunk)
+        def whenEnabled[A](flag: Flag)(thunk: => IO[A]): IO[Unit] =
+            p.module[FeatureFlags](FeatureFlags.Key).when(flag)(thunk)
     end extension
 
     extension (inline ctx: StringContext)
@@ -47,6 +48,6 @@ package object flags:
             else Left(Flag.rtc.message)
 
     extension (flag: Flag)
-        def whenEnabled[F[_], A](using p: Pillars[F])(thunk: => F[A]): F[Unit] =
-            p.module[FeatureFlags[F]](FeatureFlags.Key).when(flag)(thunk)
+        def whenEnabled[A](using p: Pillars)(thunk: => IO[A]): IO[Unit] =
+            p.module[FeatureFlags](FeatureFlags.Key).when(flag)(thunk)
 end flags

--- a/modules/flags/src/test/scala/pillars/flags/FeatureFlagsTests.scala
+++ b/modules/flags/src/test/scala/pillars/flags/FeatureFlagsTests.scala
@@ -7,38 +7,34 @@ package pillars.flags
 import cats.effect.IO
 import cats.syntax.all.*
 import munit.CatsEffectSuite
-import org.typelevel.otel4s.trace.Tracer
 import pillars.flags.*
 
 class FeatureFlagsTests extends CatsEffectSuite:
 
-    val flag1               = FeatureFlag(flag"flag1", Status.Enabled)
-    val flag2               = FeatureFlag(flag"flag2", Status.Disabled)
-    val config: FlagsConfig = FlagsConfig(flags = List(flag1, flag2))
+    private val flag1               = FeatureFlag(flag"flag1", Status.Enabled)
+    private val flag2               = FeatureFlag(flag"flag2", Status.Disabled)
+    private val config: FlagsConfig = FlagsConfig(flags = List(flag1, flag2))
 
     test("FlagManager should return the correct flag"):
-        given Tracer[IO] = Tracer.noop[IO]
-        val flag         =
+        val flag =
             for
-                manager <- FeatureFlags.createManager[IO](config)
+                manager <- FeatureFlags.createManager(config)
                 flag    <- manager.getFlag(flag"flag1")
             yield flag
         assertIO(flag, flag1.some)
 
     test("FlagManager should return None if flag is not found"):
-        given Tracer[IO] = Tracer.noop[IO]
-        val flag         =
+        val flag =
             for
-                manager <- FeatureFlags.createManager[IO](config)
+                manager <- FeatureFlags.createManager(config)
                 flag    <- manager.getFlag(flag"undefined")
             yield flag
         assertIO(flag, none)
 
     test("FlagManager should return the correct flag status"):
-        given Tracer[IO]          = Tracer.noop[IO]
         def isEnabled(flag: Flag) =
             for
-                manager <- FeatureFlags.createManager[IO](config)
+                manager <- FeatureFlags.createManager(config)
                 enabled <- manager.isEnabled(flag)
             yield enabled
         for
@@ -49,50 +45,45 @@ class FeatureFlagsTests extends CatsEffectSuite:
         end for
 
     test("FlagManager should perform the action if flag is enabled"):
-        given Tracer[IO] = Tracer.noop[IO]
-        var called       = false
-        val performed    =
+        var called    = false
+        val performed =
             for
-                manager <- FeatureFlags.createManager[IO](config)
+                manager <- FeatureFlags.createManager(config)
                 _       <- manager.when(flag"flag1")(IO { called = true })
             yield called
         assertIO(performed, true)
 
     test("FlagManager should not perform the action if flag is disabled"):
-        given Tracer[IO] = Tracer.noop[IO]
-        var called       = false
-        val performed    =
+        var called    = false
+        val performed =
             for
-                manager <- FeatureFlags.createManager[IO](config)
+                manager <- FeatureFlags.createManager(config)
                 _       <- manager.when(flag"flag2")(IO { called = true })
             yield called
         assertIO(performed, false)
 
     test("FlagManager should not perform the action if flag is not found"):
-        given Tracer[IO] = Tracer.noop[IO]
-        var called       = false
-        val performed    =
+        var called    = false
+        val performed =
             for
-                manager <- FeatureFlags.createManager[IO](config)
+                manager <- FeatureFlags.createManager(config)
                 _       <- manager.when(flag"undefined")(IO { called = true })
             yield called
         assertIO(performed, false)
 
     test("FlagManager should correctly modify an existing flag"):
-        given Tracer[IO] = Tracer.noop[IO]
-        val modified     =
+        val modified =
             for
-                manager <- FeatureFlags.createManager[IO](config)
+                manager <- FeatureFlags.createManager(config)
                 _       <- manager.setStatus(flag"flag1", Status.Disabled)
                 flag    <- manager.getFlag(flag"flag1")
             yield flag
         assertIO(modified, flag1.copy(status = Status.Disabled).some)
 
     test("FlagManager should correctly return None if flag is not found"):
-        given Tracer[IO] = Tracer.noop[IO]
-        val modified     =
+        val modified =
             for
-                manager <- FeatureFlags.createManager[IO](config)
+                manager <- FeatureFlags.createManager(config)
                 _       <- manager.setStatus(flag"undefined", Status.Disabled)
                 flag    <- manager.getFlag(flag"undefined")
             yield flag

--- a/modules/rabbitmq-fs2-tests/src/main/scala/pillars/rabbitmq/fs2/tests/RabbitMQ.scala
+++ b/modules/rabbitmq-fs2-tests/src/main/scala/pillars/rabbitmq/fs2/tests/RabbitMQ.scala
@@ -4,14 +4,11 @@
 
 package pillars.rabbitmq.fs2.tests
 
-import cats.effect.Async
+import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.std.Console
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.Port
 import com.dimafeng.testcontainers.RabbitMQContainer
-import fs2.io.net.Network
-import org.typelevel.otel4s.trace.Tracer
 import pillars.Module
 import pillars.Modules
 import pillars.ModuleSupport
@@ -19,14 +16,12 @@ import pillars.rabbitmq.fs2.RabbitMQ as RabbitMQModule
 import pillars.rabbitmq.fs2.RabbitMQConfig
 
 case class RabbitMQ(container: RabbitMQContainer) extends ModuleSupport:
-    override type M[F[_]] = RabbitMQModule[F[_]]
+    override type M = RabbitMQModule
 
     override def key: Module.Key = RabbitMQModule.Key
 
-    override def load[F[_]: Async: Network: Tracer: Console](
-        context: ModuleSupport.Context[F],
-        modules: Modules[F]
-    ): Resource[F, RabbitMQModule[F]] = RabbitMQModule(config)
+    override def load(context: ModuleSupport.Context, modules: Modules): Resource[IO, RabbitMQModule] =
+        RabbitMQModule(config)
 
     private val config = RabbitMQConfig(
       host = Host.fromString(container.host).get,

--- a/modules/rabbitmq-fs2/src/test/scala/pillars/rabbitmq/fs2/RabbitMQTests.scala
+++ b/modules/rabbitmq-fs2/src/test/scala/pillars/rabbitmq/fs2/RabbitMQTests.scala
@@ -31,7 +31,7 @@ class RabbitMQTests extends CatsEffectSuite, TestContainerForEach:
       bindings = Seq(RabbitMQContainer.Binding(exchange.value, queue.value, routingKey.value))
     )
 
-    given Pillars[IO] = new Pillars[IO]:
+    given Pillars = new Pillars:
         def appInfo                         = ???
         def observability                   = ???
         def config                          = ???
@@ -50,7 +50,7 @@ class RabbitMQTests extends CatsEffectSuite, TestContainerForEach:
     test("allow exchanging messages"):
         withContainers { container =>
             for
-                client <- RabbitMQ[IO](configFor(container)).map(_.client)
+                client <- RabbitMQ(configFor(container)).map(_.client)
                 _      <- client.createConnectionChannel.evalMap { implicit channel =>
                               for
                                   publisher  <- client.createPublisher[String](exchange, routingKey)

--- a/modules/redis-rediculous-tests/src/main/scala/pillars/redis_rediculous/tests/Redis.scala
+++ b/modules/redis-rediculous-tests/src/main/scala/pillars/redis_rediculous/tests/Redis.scala
@@ -4,14 +4,11 @@
 
 package pillars.redis_rediculous.tests
 
-import cats.effect.Async
+import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.std.Console
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.Port
 import com.dimafeng.testcontainers.RedisContainer
-import fs2.io.net.Network
-import org.typelevel.otel4s.trace.Tracer
 import pillars.Module
 import pillars.Modules
 import pillars.ModuleSupport
@@ -19,14 +16,12 @@ import pillars.probes.ProbeConfig
 import pillars.redis_rediculous.RedisConfig
 
 case class Redis(container: RedisContainer) extends ModuleSupport:
-    override type M[F[_]] = pillars.redis_rediculous.Redis[F]
+    override type M = pillars.redis_rediculous.Redis
 
     override def key: Module.Key = pillars.redis_rediculous.Redis.key
 
-    override def load[F[_]: Async: Network: Tracer: Console](
-        context: ModuleSupport.Context[F],
-        modules: Modules[F]
-    ): Resource[F, pillars.redis_rediculous.Redis[F]] = pillars.redis_rediculous.Redis.load[F](redisConfig)
+    override def load(context: ModuleSupport.Context, modules: Modules): Resource[IO, pillars.redis_rediculous.Redis] =
+        pillars.redis_rediculous.Redis.load(redisConfig)
 
     private def redisConfig: RedisConfig =
         RedisConfig(


### PR DESCRIPTION
## Motivation

1. Simplification of code architecture
- Removing the generic type parameter F[_] reduces complexity in API design and implementation
- Concrete IO type makes code more approachable for new contributors

2. Reduced boilerplate
- Eliminating type class constraints and contexts simplifies method signatures
- No need for complex implicit handling and type class derivation

3. Improved compile times
- Fewer implicits and type class resolutions lead to faster compilation
- Simpler type inference requirements

## Details

- Replace type class-based abstractions with concrete IO type
- Update relevant service implementations
- Adjust tests to work with IO instead of generic F[_]

BREAKING CHANGE: This changes the fundamental abstraction approach from tagless final (F[_]) to concrete IO type, requiring API consumers to adapt their code accordingly.