### PR TITLE
fix!: expose AdminServer controller from application context

### DIFF
--- a/modules/core-tests/src/main/scala/pillars/tests/suite.scala
+++ b/modules/core-tests/src/main/scala/pillars/tests/suite.scala
@@ -20,6 +20,8 @@ import pillars.ApiServer
 import pillars.App
 import pillars.AppInfo
 import pillars.Config.PillarsConfig
+import pillars.Controller
+import pillars.HttpServer
 import pillars.Module
 import pillars.Modules
 import pillars.Observability
@@ -59,11 +61,13 @@ trait PillarsSuite extends CatsEffectSuite, TestContainersSuite:
             override def appInfo: AppInfo                                = BuildInfo.toAppInfo
             override def observability: Observability                    = obs
             override def config: PillarsConfig                           = conf
-            override def apiServer: ApiServer                            = ApiServer.noop
+            override def apiServer: HttpServer                           = HttpServer.noop
             override def logger: Scribe[IO]                              = scribe.cats.io
             override def readConfig[T](using decoder: Decoder[T]): IO[T] =
                 IO.raiseError(new NotImplementedError("readConfig is not available in tests"))
             override def module[T](key: Module.Key): T                   = modules.get(key)
+            override def adminServer: HttpServer                         = HttpServer.noop
+            override def adminControllers: List[Controller]              = Nil
         end for
     end fromContainer
 

--- a/modules/core/src/main/scala/pillars/Config.scala
+++ b/modules/core/src/main/scala/pillars/Config.scala
@@ -31,7 +31,7 @@ trait Config
 
 object Config:
     val defaultCirceConfig: Configuration =
-        Configuration.default.withSnakeCaseMemberNames.withSnakeCaseConstructorNames.withDefaults
+        Configuration.default.withKebabCaseMemberNames.withKebabCaseConstructorNames.withDefaults
     case class PillarsConfig(
         name: App.Name,
         log: Logging.Config = Logging.Config(),

--- a/modules/example/src/main/resources/config.yaml
+++ b/modules/example/src/main/resources/config.yaml
@@ -47,7 +47,7 @@ api:
       body: true
       level: info
   open-api:
-    enabled: false
+    enabled: true
     path-prefix: ["docs"]
     yaml-name: "pillars-example.yaml"
     context-path: []
@@ -66,7 +66,7 @@ admin:
       body: true
       level: debug
   open-api:
-    enabled: false
+    enabled: true
     path-prefix: ["docs"]
     yaml-name: "pillars-example.yaml"
     context-path: []

--- a/modules/example/src/main/scala/example/app.scala
+++ b/modules/example/src/main/scala/example/app.scala
@@ -36,9 +36,10 @@ object app extends pillars.IOApp(DB, DBMigration, FeatureFlags, HttpClient): // 
                          size <- response.body.compile.count
                          _    <- logger.info(s"Body: $size bytes")
                      yield ()
-            _ <- server.start(homeController, userController)   // // <5>
         yield ()
         end for
     end run
+
+    override def controllers: Run[List[Controller]] = List(homeController, userController)
 end app
 // end::quick-start[]

--- a/modules/rabbitmq-fs2/src/test/scala/pillars/rabbitmq/fs2/RabbitMQTests.scala
+++ b/modules/rabbitmq-fs2/src/test/scala/pillars/rabbitmq/fs2/RabbitMQTests.scala
@@ -39,6 +39,8 @@ class RabbitMQTests extends CatsEffectSuite, TestContainerForEach:
         def logger                          = scribe.cats.io
         def readConfig[T](using Decoder[T]) = ???
         def module[T](key: Module.Key): T   = ???
+        def adminServer                     = ???
+        def adminControllers                = ???
 
     given Tracer[IO] = Tracer.noop[IO]
 


### PR DESCRIPTION
This change ensures that the AdminServer controller is properly exposed from the application context, fixing the configuration setup needed for the admin endpoints to be accessible.

BREAKING CHANGE: Changes how API controllers are defined and started. Controllers are now defined in the `controllers` field on `App` instead of being manually started in `Pillars.run`. The API server is now automatically started.

Fixes #157